### PR TITLE
Generic errors

### DIFF
--- a/seesaw.sh
+++ b/seesaw.sh
@@ -175,8 +175,7 @@ do
       fi
 
     else
-      echo "Error downloading '$itemname'."
-      exit 6
+      echo "Error downloading '$itemname'." >> errors.log
     fi
   fi
 done


### PR DESCRIPTION
I modified my version of seesaw.sh to not stop the script when it runs into generic errors at the bottom, and instead write to "errors.log". Sample output for me was:

$ cat errors.log
Error downloading 'com/oasis/benidorm'.
Error downloading 'com/emachines/e11'.
Error downloading 'com/member/sertyui'.

Let me know if you think this is appropriate.
